### PR TITLE
Exclude the `tsconfig.json` file from new releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "defer-to-connect",
   "version": "1.1.1",
   "description": "The safe way to handle the `connect` socket event",
-	"main": "dist",
-	"files": ["dist"],
+  "main": "dist",
+  "files": ["dist"],
   "scripts": {
     "build": "del-cli dist && tsc",
     "prepublishOnly": "npm run build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "defer-to-connect",
   "version": "1.1.1",
   "description": "The safe way to handle the `connect` socket event",
-  "main": "dist",
+	"main": "dist",
+	"files": ["dist"],
   "scripts": {
     "build": "del-cli dist && tsc",
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
Adding the `files` attribute so that npm package only includes necessary files (Cf. #6 )

```shell
~/ref/defer-to-connect$ npm publish --dry-run

> defer-to-connect@1.1.1 prepublishOnly .
> npm run build


> defer-to-connect@1.1.1 build /Users/xxx/ref/defer-to-connect
> del-cli dist && tsc

npm notice
npm notice 📦  defer-to-connect@1.1.1
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 1.5kB dist/index.js
npm notice 1.6kB package.json
npm notice 951B  README.md
npm notice 346B  dist/index.d.ts
npm notice === Tarball Details ===
npm notice name:          defer-to-connect
npm notice version:       1.1.1
npm notice package size:  2.4 kB
npm notice unpacked size: 5.4 kB
npm notice shasum:        5b951fb0165161c29ca5635672772f45d8600b42
npm notice integrity:     sha512-mzkA7swfXs/c8[...]bv01T4Tk0QGaQ==
npm notice total files:   5
npm notice
+ defer-to-connect@1.1.1
```
