### PR TITLE
Fix types property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,5 @@
       }
     }
   },
-  "types": "dist/source"
+  "types": "dist/source/index.d.ts"
 }


### PR DESCRIPTION
The `types` property should point to your bundled declaration file not the directory. 

See:

- [Including declarations in your npm package - TypeScript](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html)
- [https://github.com/motdotla/dotenv/pull/476](https://github.com/motdotla/dotenv/pull/476)